### PR TITLE
Fix Supabase login session handling

### DIFF
--- a/app/actions/login.ts
+++ b/app/actions/login.ts
@@ -1,12 +1,19 @@
 "use server"
 
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
-import { cookies } from "next/headers"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+
+function getSafeRedirectPath(redirectTo: FormDataEntryValue | null) {
+    if (typeof redirectTo !== "string" || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+        return "/dashboard"
+    }
+
+    return redirectTo
+}
 
 export async function login(formData: FormData) {
     const email = formData.get("email") as string
     const password = formData.get("password") as string
-    const redirectTo = formData.get("redirectTo") as string || "/dashboard"
+    const redirectTo = getSafeRedirectPath(formData.get("redirectTo"))
 
     // Validate inputs
     if (!email || !password) {
@@ -24,7 +31,7 @@ export async function login(formData: FormData) {
     }
 
     try {
-        const supabase = createServerActionClient({ cookies })
+        const supabase = await createServerSupabaseClient()
 
         // Attempt to sign in
         const { data, error } = await supabase.auth.signInWithPassword({
@@ -89,4 +96,4 @@ export async function login(formData: FormData) {
             error: "An unexpected error occurred during login",
         }
     }
-} 
+}

--- a/app/actions/mfa-actions.ts
+++ b/app/actions/mfa-actions.ts
@@ -1,14 +1,21 @@
 "use server"
 
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
-import { cookies } from "next/headers"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+
+function getSafeRedirectPath(redirectTo: FormDataEntryValue | null) {
+    if (typeof redirectTo !== "string" || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+        return "/dashboard"
+    }
+
+    return redirectTo
+}
 
 // Keep only MFA verification for auth flow - other MFA operations can be done securely client-side
 export async function verifyMFA(formData: FormData) {
     const factorId = formData.get("factorId") as string
     const challengeId = formData.get("challengeId") as string
     const code = formData.get("code") as string
-    const redirectTo = formData.get("redirectTo") as string || "/dashboard"
+    const redirectTo = getSafeRedirectPath(formData.get("redirectTo"))
 
     // Validate inputs
     if (!factorId || !challengeId || !code) {
@@ -18,7 +25,7 @@ export async function verifyMFA(formData: FormData) {
     }
 
     try {
-        const supabase = createServerActionClient({ cookies })
+        const supabase = await createServerSupabaseClient()
 
         // Verify the MFA code
         const { error: verifyError } = await supabase.auth.mfa.verify({
@@ -44,4 +51,4 @@ export async function verifyMFA(formData: FormData) {
             error: "An unexpected error occurred during MFA verification",
         }
     }
-} 
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,7 +4,7 @@ import LoginForm from "@/components/auth/login-form"
 import LandingNavbar from "@/components/landing/landing-navbar"
 
 export default async function LoginPage() {
-  const supabase = createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient()
 
   const {
     data: { session },

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -5,7 +5,7 @@ import RegisterForm from "@/components/auth/register-form"
 import LandingNavbar from "@/components/landing/landing-navbar"
 
 export default async function RegisterPage() {
-  const supabase = createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient()
 
   const {
     data: { session },

--- a/components/auth/forgot-password-form.tsx
+++ b/components/auth/forgot-password-form.tsx
@@ -5,7 +5,7 @@ import ForgotPasswordForm from "@/components/auth/forgot-password-form"
 import LandingNavbar from "@/components/landing/landing-navbar"
 
 export default async function ForgotPasswordPage() {
-  const supabase = createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient()
 
   const {
     data: { session },

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,10 +1,9 @@
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 import type { Database } from "@/types/supabase"
-import { getSiteUrl } from "./server-config"
 
-export function createServerSupabaseClient() {
-  const cookieStore = cookies()
+export async function createServerSupabaseClient() {
+  const cookieStore = await cookies()
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
@@ -36,7 +35,6 @@ export function createServerSupabaseClient() {
         autoRefreshToken: true,
         detectSessionInUrl: true,
         persistSession: true,
-        redirectTo: `${getSiteUrl()}/auth/callback`,
       },
     },
   )


### PR DESCRIPTION
### Motivation
- Fix broken login/MFA flows caused by inconsistent server-side cookie handling for Supabase sessions and an unsupported `redirectTo` auth option in the shared server client.
- Ensure server pages and server actions read/write auth cookies using the same SSR Supabase client so sessions persist after sign-in.

### Description
- Made the shared server Supabase client async by awaiting Next.js `cookies()` and removed the unsupported `redirectTo` option from client construction in `lib/supabase/server.ts`.
- Updated server actions `login` and `verifyMFA` to use the shared `createServerSupabaseClient()` (awaited) instead of `createServerActionClient`, so auth cookies are handled consistently.
- Updated auth-related pages to `await createServerSupabaseClient()` before checking `supabase.auth.getSession()` so redirects behave correctly on server-rendered pages (`app/login/page.tsx`, `app/register/page.tsx`, `components/auth/forgot-password-form.tsx`).
- Added `getSafeRedirectPath` helper in login and MFA actions to sanitize `redirectTo` values and avoid unsafe external redirects.

### Testing
- Ran `git diff --check` which passed.
- Ran `npx tsc --noEmit` which failed due to unrelated pre-existing TypeScript errors in other parts of the codebase (missing modules and typing issues), not caused by these auth changes.
- Ran `npm run build` which failed because the Next.js build could not fetch the Google Font `Inter` from `fonts.googleapis.com` in this environment, blocking a full production build.
- Ran `npm run lint` which failed because ESLint v10 expects an `eslint.config.*` file and the repository does not provide one.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d1c73f24c8327a0d7ba06779e6062)