### PR TITLE
Use async server Supabase client, add safe redirect handling, and update server cookie adapter

### DIFF
--- a/app/actions/login.ts
+++ b/app/actions/login.ts
@@ -1,12 +1,19 @@
 "use server"
 
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
-import { cookies } from "next/headers"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+
+function getSafeRedirectPath(redirectTo: FormDataEntryValue | null) {
+    if (typeof redirectTo !== "string" || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+        return "/dashboard"
+    }
+
+    return redirectTo
+}
 
 export async function login(formData: FormData) {
     const email = formData.get("email") as string
     const password = formData.get("password") as string
-    const redirectTo = formData.get("redirectTo") as string || "/dashboard"
+    const redirectTo = getSafeRedirectPath(formData.get("redirectTo"))
 
     // Validate inputs
     if (!email || !password) {
@@ -24,7 +31,7 @@ export async function login(formData: FormData) {
     }
 
     try {
-        const supabase = createServerActionClient({ cookies })
+        const supabase = await createServerSupabaseClient()
 
         // Attempt to sign in
         const { data, error } = await supabase.auth.signInWithPassword({
@@ -89,4 +96,4 @@ export async function login(formData: FormData) {
             error: "An unexpected error occurred during login",
         }
     }
-} 
+}

--- a/app/actions/mfa-actions.ts
+++ b/app/actions/mfa-actions.ts
@@ -1,14 +1,21 @@
 "use server"
 
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
-import { cookies } from "next/headers"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+
+function getSafeRedirectPath(redirectTo: FormDataEntryValue | null) {
+    if (typeof redirectTo !== "string" || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+        return "/dashboard"
+    }
+
+    return redirectTo
+}
 
 // Keep only MFA verification for auth flow - other MFA operations can be done securely client-side
 export async function verifyMFA(formData: FormData) {
     const factorId = formData.get("factorId") as string
     const challengeId = formData.get("challengeId") as string
     const code = formData.get("code") as string
-    const redirectTo = formData.get("redirectTo") as string || "/dashboard"
+    const redirectTo = getSafeRedirectPath(formData.get("redirectTo"))
 
     // Validate inputs
     if (!factorId || !challengeId || !code) {
@@ -18,7 +25,7 @@ export async function verifyMFA(formData: FormData) {
     }
 
     try {
-        const supabase = createServerActionClient({ cookies })
+        const supabase = await createServerSupabaseClient()
 
         // Verify the MFA code
         const { error: verifyError } = await supabase.auth.mfa.verify({
@@ -44,4 +51,4 @@ export async function verifyMFA(formData: FormData) {
             error: "An unexpected error occurred during MFA verification",
         }
     }
-} 
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,7 +4,7 @@ import LoginForm from "@/components/auth/login-form"
 import LandingNavbar from "@/components/landing/landing-navbar"
 
 export default async function LoginPage() {
-  const supabase = createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient()
 
   const {
     data: { session },

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -5,7 +5,7 @@ import RegisterForm from "@/components/auth/register-form"
 import LandingNavbar from "@/components/landing/landing-navbar"
 
 export default async function RegisterPage() {
-  const supabase = createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient()
 
   const {
     data: { session },

--- a/components/auth/forgot-password-form.tsx
+++ b/components/auth/forgot-password-form.tsx
@@ -5,7 +5,7 @@ import ForgotPasswordForm from "@/components/auth/forgot-password-form"
 import LandingNavbar from "@/components/landing/landing-navbar"
 
 export default async function ForgotPasswordPage() {
-  const supabase = createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient()
 
   const {
     data: { session },

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,33 +1,26 @@
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 import type { Database } from "@/types/supabase"
-import { getSiteUrl } from "./server-config"
 
-export function createServerSupabaseClient() {
-  const cookieStore = cookies()
+export async function createServerSupabaseClient() {
+  const cookieStore = await cookies()
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value
+        getAll() {
+          return cookieStore.getAll()
         },
-        set(name: string, value: string, options: any) {
+        setAll(cookiesToSet) {
           try {
-            cookieStore.set({ name, value, ...options })
-          } catch (error) {
-            // Handle cookie setting errors
-            console.error("Error setting cookie:", error)
-          }
-        },
-        remove(name: string, options: any) {
-          try {
-            cookieStore.set({ name, value: "", ...options })
-          } catch (error) {
-            // Handle cookie removal errors
-            console.error("Error removing cookie:", error)
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options)
+            })
+          } catch {
+            // Server Components cannot set cookies while rendering. In those
+            // cases, middleware or a Server Action refreshes the session.
           }
         },
       },
@@ -36,7 +29,6 @@ export function createServerSupabaseClient() {
         autoRefreshToken: true,
         detectSessionInUrl: true,
         persistSession: true,
-        redirectTo: `${getSiteUrl()}/auth/callback`,
       },
     },
   )


### PR DESCRIPTION
### Motivation

- Ensure server-side Supabase client works correctly in Server Components and Server Actions by awaiting cookie access and adapting cookie APIs. 
- Prevent open redirect vectors by validating `redirectTo` values in login and MFA flows. 
- Simplify MFA and login server actions to use the centralized server client implementation.

### Description

- Reworked `createServerSupabaseClient` in `lib/supabase/server.ts` to be `async`, await `cookies()`, switch the cookie adapter to `getAll`/`setAll` shape, and remove the `redirectTo` site config usage. 
- Replaced uses of the previous action client with `await createServerSupabaseClient()` across pages and server actions (`login`, `mfa-actions`, `login/page.tsx`, `register/page.tsx`, `forgot-password` page). 
- Added `getSafeRedirectPath` helper to `app/actions/login.ts` and `app/actions/mfa-actions.ts` to validate `redirectTo` and default to `/dashboard` for unsafe values. 
- Kept MFA verification and login flow logic but updated calls to the new server client and refined cookie-setting error handling to avoid setting cookies during Server Component rendering.

### Testing

- Ran a TypeScript build (`npm run build`) to validate types and server client usage, which completed successfully. 
- Executed the existing automated test suite (`npm test`), and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d1c73f24c8327a0d7ba06779e6062)