### PR TITLE
Refactor server Supabase client, secure redirect handling, and middleware MFA/session enforcement

### DIFF
--- a/app/actions/login.ts
+++ b/app/actions/login.ts
@@ -1,12 +1,19 @@
 "use server"
 
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
-import { cookies } from "next/headers"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+
+function getSafeRedirectPath(redirectTo: FormDataEntryValue | null) {
+    if (typeof redirectTo !== "string" || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+        return "/dashboard"
+    }
+
+    return redirectTo
+}
 
 export async function login(formData: FormData) {
     const email = formData.get("email") as string
     const password = formData.get("password") as string
-    const redirectTo = formData.get("redirectTo") as string || "/dashboard"
+    const redirectTo = getSafeRedirectPath(formData.get("redirectTo"))
 
     // Validate inputs
     if (!email || !password) {
@@ -24,7 +31,7 @@ export async function login(formData: FormData) {
     }
 
     try {
-        const supabase = createServerActionClient({ cookies })
+        const supabase = await createServerSupabaseClient()
 
         // Attempt to sign in
         const { data, error } = await supabase.auth.signInWithPassword({
@@ -89,4 +96,4 @@ export async function login(formData: FormData) {
             error: "An unexpected error occurred during login",
         }
     }
-} 
+}

--- a/app/actions/mfa-actions.ts
+++ b/app/actions/mfa-actions.ts
@@ -1,14 +1,21 @@
 "use server"
 
-import { createServerActionClient } from "@supabase/auth-helpers-nextjs"
-import { cookies } from "next/headers"
+import { createServerSupabaseClient } from "@/lib/supabase/server"
+
+function getSafeRedirectPath(redirectTo: FormDataEntryValue | null) {
+    if (typeof redirectTo !== "string" || !redirectTo.startsWith("/") || redirectTo.startsWith("//")) {
+        return "/dashboard"
+    }
+
+    return redirectTo
+}
 
 // Keep only MFA verification for auth flow - other MFA operations can be done securely client-side
 export async function verifyMFA(formData: FormData) {
     const factorId = formData.get("factorId") as string
     const challengeId = formData.get("challengeId") as string
     const code = formData.get("code") as string
-    const redirectTo = formData.get("redirectTo") as string || "/dashboard"
+    const redirectTo = getSafeRedirectPath(formData.get("redirectTo"))
 
     // Validate inputs
     if (!factorId || !challengeId || !code) {
@@ -18,7 +25,7 @@ export async function verifyMFA(formData: FormData) {
     }
 
     try {
-        const supabase = createServerActionClient({ cookies })
+        const supabase = await createServerSupabaseClient()
 
         // Verify the MFA code
         const { error: verifyError } = await supabase.auth.mfa.verify({
@@ -44,4 +51,4 @@ export async function verifyMFA(formData: FormData) {
             error: "An unexpected error occurred during MFA verification",
         }
     }
-} 
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -4,7 +4,7 @@ import LoginForm from "@/components/auth/login-form"
 import LandingNavbar from "@/components/landing/landing-navbar"
 
 export default async function LoginPage() {
-  const supabase = createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient()
 
   const {
     data: { session },

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -5,7 +5,7 @@ import RegisterForm from "@/components/auth/register-form"
 import LandingNavbar from "@/components/landing/landing-navbar"
 
 export default async function RegisterPage() {
-  const supabase = createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient()
 
   const {
     data: { session },

--- a/components/auth/forgot-password-form.tsx
+++ b/components/auth/forgot-password-form.tsx
@@ -5,7 +5,7 @@ import ForgotPasswordForm from "@/components/auth/forgot-password-form"
 import LandingNavbar from "@/components/landing/landing-navbar"
 
 export default async function ForgotPasswordPage() {
-  const supabase = createServerSupabaseClient()
+  const supabase = await createServerSupabaseClient()
 
   const {
     data: { session },

--- a/components/landing/landing-navbar.tsx
+++ b/components/landing/landing-navbar.tsx
@@ -1,13 +1,12 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import Link from "next/link"
 import Image from "next/image"
 import { usePathname } from "next/navigation"
 import { Menu, X } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { cn } from "@/lib/utils"
-import { supabase } from "@/lib/supabase/client"
 
 // Modified navItems to only include Features
 const navItems = [
@@ -18,26 +17,12 @@ const navItems = [
 export default function LandingNavbar() {
   const pathname = usePathname()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const [isAuthenticated, setIsAuthenticated] = useState(false)
-
-  // Check authentication status on component mount
-  useEffect(() => {
-    async function checkAuth() {
-      const { data } = await supabase.auth.getSession()
-      setIsAuthenticated(!!data.session)
-    }
-
-    checkAuth()
-  }, [])
-
-  // Determine home link based on authentication status
-  const homeLink = isAuthenticated ? "/dashboard" : "/"
 
   return (
     <header className="sticky top-0 z-50 w-full border-b bg-white">
       <div className="container mx-auto flex h-16 items-center justify-between px-4 md:px-6">
         <div className="flex items-center">
-          <Link href={homeLink} className="flex items-center space-x-2">
+          <Link href="/" className="flex items-center space-x-2">
             <div className="relative w-8 h-8">
               <Image src="/trust-impact-logo.png" alt="Trust Impact Logo" fill className="object-contain" />
             </div>

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,42 +1,39 @@
 import { createServerClient } from "@supabase/ssr"
 import { cookies } from "next/headers"
 import type { Database } from "@/types/supabase"
-import { getSiteUrl } from "./server-config"
 
-export function createServerSupabaseClient() {
-  const cookieStore = cookies()
+function isLegacyBase64AuthCookie(cookie: { name: string; value: string }) {
+  return cookie.name.endsWith("-auth-token") && cookie.value.startsWith("base64-")
+}
+
+export async function createServerSupabaseClient() {
+  const cookieStore = await cookies()
 
   return createServerClient<Database>(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value
+        getAll() {
+          return cookieStore.getAll().filter((cookie) => !isLegacyBase64AuthCookie(cookie))
         },
-        set(name: string, value: string, options: any) {
+        setAll(cookiesToSet) {
           try {
-            cookieStore.set({ name, value, ...options })
-          } catch (error) {
-            // Handle cookie setting errors
-            console.error("Error setting cookie:", error)
-          }
-        },
-        remove(name: string, options: any) {
-          try {
-            cookieStore.set({ name, value: "", ...options })
-          } catch (error) {
-            // Handle cookie removal errors
-            console.error("Error removing cookie:", error)
+            cookiesToSet.forEach(({ name, value, options }) => {
+              cookieStore.set(name, value, options)
+            })
+          } catch {
+            // Server Components cannot set cookies while rendering. In those
+            // cases, middleware or a Server Action refreshes the session.
           }
         },
       },
+      cookieEncoding: "raw",
       auth: {
         flowType: "pkce",
         autoRefreshToken: true,
         detectSessionInUrl: true,
         persistSession: true,
-        redirectTo: `${getSiteUrl()}/auth/callback`,
       },
     },
   )

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,15 +1,13 @@
-import { createMiddlewareClient } from "@supabase/auth-helpers-nextjs"
+import { createServerClient } from "@supabase/ssr"
 import { NextResponse } from "next/server"
 import type { NextRequest } from "next/server"
 
-export async function middleware(request: NextRequest) {
-  const res = NextResponse.next()
-  const supabase = createMiddlewareClient({ req: request, res })
+function isLegacyBase64AuthCookie(cookie: { name: string; value: string }) {
+  return cookie.name.endsWith("-auth-token") && cookie.value.startsWith("base64-")
+}
 
-  // Refresh session if expired
-  const {
-    data: { session },
-  } = await supabase.auth.getSession()
+export async function middleware(request: NextRequest) {
+  let response = NextResponse.next({ request })
 
   // Define public routes that don't require authentication
   const publicRoutes = [
@@ -39,18 +37,43 @@ export async function middleware(request: NextRequest) {
     // Allow common static file extensions
     /\.(png|jpg|jpeg|gif|svg|ico|css|js|woff|woff2|ttf|eot)$/.test(request.nextUrl.pathname)
   ) {
-    return res
+    return response
   }
 
+  const supabaseMiddleware = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookieEncoding: "raw",
+      cookies: {
+        getAll() {
+          return request.cookies.getAll().filter((cookie) => !isLegacyBase64AuthCookie(cookie))
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
+          response = NextResponse.next({ request })
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options)
+          })
+        },
+      },
+    },
+  )
+
+  // Refresh session if expired
+  const {
+    data: { session: currentSession },
+  } = await supabaseMiddleware.auth.getSession()
+
   // If no session and trying to access protected route, redirect to login
-  if (!session) {
+  if (!currentSession) {
     const redirectUrl = new URL("/login", request.url)
     redirectUrl.searchParams.set("redirectTo", request.nextUrl.pathname)
     return NextResponse.redirect(redirectUrl)
   }
 
   // Check if user has MFA factors enrolled
-  const { data: factors, error: factorsError } = await supabase.auth.mfa.listFactors()
+  const { data: factors, error: factorsError } = await supabaseMiddleware.auth.mfa.listFactors()
 
   if (!factorsError && factors) {
     // Check if user has any verified MFA factors
@@ -58,7 +81,7 @@ export async function middleware(request: NextRequest) {
 
     if (hasVerifiedMFA) {
       // User has MFA enrolled, check if they're at AAL2
-      const { data: aalData } = await supabase.auth.mfa.getAuthenticatorAssuranceLevel()
+      const { data: aalData } = await supabaseMiddleware.auth.mfa.getAuthenticatorAssuranceLevel()
 
       if (aalData?.currentLevel !== 'aal2') {
         // User has MFA but hasn't verified it in this session - redirect to login
@@ -70,11 +93,11 @@ export async function middleware(request: NextRequest) {
   }
 
   // Set cache control headers to prevent caching of authenticated pages
-  res.headers.set('Cache-Control', 'no-store, must-revalidate')
-  res.headers.set('Pragma', 'no-cache')
-  res.headers.set('Expires', '0')
+  response.headers.set('Cache-Control', 'no-store, must-revalidate')
+  response.headers.set('Pragma', 'no-cache')
+  response.headers.set('Expires', '0')
 
-  return res
+  return response
 }
 
 export const config = {


### PR DESCRIPTION
### Motivation

- Consolidate and fix server-side Supabase client logic and cookie handling to support Server Actions/SSR and avoid legacy cookie issues.  
- Prevent open-redirects from form-provided `redirectTo` values during login/MFA flows.  
- Centralize session checks and MFA enforcement in middleware to ensure protected pages require proper AAL2 session state.  
- Remove client-side session checks from the landing navbar to simplify the client bundle and avoid unnecessary session fetches.

### Description

- Replace previous Supabase client usage with an async `createServerSupabaseClient()` in `lib/supabase/server.ts` and update call sites to `await` it (pages and server actions).  
- Implement secure redirect validation with a `getSafeRedirectPath` helper in `app/actions/login.ts` and `app/actions/mfa-actions.ts` to sanitize `redirectTo`.  
- Rework `lib/supabase/server.ts` cookies API to use `cookies.getAll()` and `setAll()` while filtering legacy base64 auth cookies, set `cookieEncoding: "raw"`, and enable PKCE/auth flow options for server usage.  
- Update `middleware.ts` to construct a server Supabase client with matching cookie behavior, propagate cookie changes into the outgoing `NextResponse`, enforce protected routes, verify MFA factors and AAL level, and set no-cache headers on protected responses.  
- Simplify `LandingNavbar` by removing the `useEffect` auth check and always pointing the logo link to `/`.  
- Update login, register, and forgot-password pages to `await createServerSupabaseClient()` and adjust related server-action usage to the new client API.

### Testing

- Ran TypeScript type-check with `tsc --noEmit`, which completed successfully.  
- Performed a Next.js production build with `next build`, which completed successfully.  
- Ran linter via `eslint .`, which did not report blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d1c73f24c8327a0d7ba06779e6062)