### PR TITLE
Fix intermittent MFA verify failure on serverless hosting

### DIFF
--- a/app/actions/login.ts
+++ b/app/actions/login.ts
@@ -66,21 +66,14 @@ export async function login(formData: FormData) {
         const totpFactor = factors?.totp?.find(factor => factor.status === 'verified')
 
         if (totpFactor) {
-            // MFA is required, create challenge
-            const { data: challengeData, error: challengeError } = await supabase.auth.mfa.challenge({
-                factorId: totpFactor.id
-            })
-
-            if (challengeError) {
-                return {
-                    error: challengeError.message,
-                }
-            }
-
+            // MFA is required. The challenge is created together with the
+            // verification in verifyMFA (challengeAndVerify): creating it here
+            // in a separate server invocation can fail on serverless hosting,
+            // where challenge and verify may egress from different IPs and
+            // Supabase rejects the mismatch.
             return {
                 requiresMFA: true,
                 factorId: totpFactor.id,
-                challengeId: challengeData.id,
                 redirectTo,
             }
         }

--- a/app/actions/mfa-actions.ts
+++ b/app/actions/mfa-actions.ts
@@ -13,12 +13,11 @@ function getSafeRedirectPath(redirectTo: FormDataEntryValue | null) {
 // Keep only MFA verification for auth flow - other MFA operations can be done securely client-side
 export async function verifyMFA(formData: FormData) {
     const factorId = formData.get("factorId") as string
-    const challengeId = formData.get("challengeId") as string
     const code = formData.get("code") as string
     const redirectTo = getSafeRedirectPath(formData.get("redirectTo"))
 
     // Validate inputs
-    if (!factorId || !challengeId || !code) {
+    if (!factorId || !code) {
         return {
             error: "All MFA fields are required",
         }
@@ -27,10 +26,11 @@ export async function verifyMFA(formData: FormData) {
     try {
         const supabase = await createServerSupabaseClient()
 
-        // Verify the MFA code
-        const { error: verifyError } = await supabase.auth.mfa.verify({
+        // Create the challenge and verify the code in the same invocation so
+        // both requests reach Supabase from the same IP (it rejects a verify
+        // coming from a different IP than the challenge).
+        const { error: verifyError } = await supabase.auth.mfa.challengeAndVerify({
             factorId,
-            challengeId,
             code,
         })
 

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -19,7 +19,6 @@ export default function LoginForm() {
   const [error, setError] = useState<string | null>(null)
   const [mfaData, setMfaData] = useState<{
     factorId: string
-    challengeId: string
     redirectTo: string
   } | null>(null)
 
@@ -41,7 +40,6 @@ export default function LoginForm() {
       } else if (result?.requiresMFA) {
         setMfaData({
           factorId: result.factorId,
-          challengeId: result.challengeId,
           redirectTo: result.redirectTo,
         })
       } else if (result?.success && result?.redirectTo) {
@@ -66,11 +64,7 @@ export default function LoginForm() {
             Enter the verification code from your authenticator app
           </p>
         </div>
-        <MFAVerificationForm
-          factorId={mfaData.factorId}
-          challengeId={mfaData.challengeId}
-          redirectTo={mfaData.redirectTo}
-        />
+        <MFAVerificationForm factorId={mfaData.factorId} redirectTo={mfaData.redirectTo} />
       </div>
     )
   }

--- a/components/auth/mfa-verification-form.tsx
+++ b/components/auth/mfa-verification-form.tsx
@@ -11,11 +11,10 @@ import { Alert, AlertDescription } from "@/components/ui/alert"
 
 interface MFAVerificationFormProps {
     factorId: string
-    challengeId: string
     redirectTo: string
 }
 
-export default function MFAVerificationForm({ factorId, challengeId, redirectTo }: MFAVerificationFormProps) {
+export default function MFAVerificationForm({ factorId, redirectTo }: MFAVerificationFormProps) {
     const router = useRouter()
     const [code, setCode] = useState("")
     const [isLoading, setIsLoading] = useState(false)
@@ -29,7 +28,6 @@ export default function MFAVerificationForm({ factorId, challengeId, redirectTo 
         try {
             const formData = new FormData()
             formData.append("factorId", factorId)
-            formData.append("challengeId", challengeId)
             formData.append("code", code)
             formData.append("redirectTo", redirectTo)
 


### PR DESCRIPTION
## Problem

Follow-up to #12 (this commit was pushed to the branch just after that PR was merged). During real login testing, MFA verification intermittently failed with Supabase's `mfa_ip_address_mismatch` error — "Challenge and verify IP addresses mismatch" — and then succeeded on retry.

Supabase records the requester's IP when an MFA challenge is created and rejects verification arriving from a different IP. The challenge was created in the `login` server action and verified in a *separate* server action invocation; on Vercel, two invocations can egress from different outbound IPs, making the failure random (warm instance reuse → same IP → success, which is why retries work).

## Changes

- `app/actions/mfa-actions.ts`: verify the TOTP code with `mfa.challengeAndVerify()`, which creates the challenge and verifies it within one server invocation — both requests always share one IP, eliminating the mismatch by construction.
- `app/actions/login.ts`: stop pre-creating the challenge at password-login time (TOTP challenges are just a nonce; nothing is sent to the user).
- `components/auth/login-form.tsx`, `components/auth/mfa-verification-form.tsx`: drop the now-unneeded `challengeId` plumbing.

MFA *enrollment* (`components/profile/mfa-form.tsx`) is untouched — it runs entirely in the browser, so its challenge and verify always came from the same IP.

## Verification

- `pnpm build` passes; `npx tsc --noEmit` error count unchanged from baseline.
- `challengeId` no longer appears anywhere in the login path (only in the browser-side enrollment form, where it belongs).
- **Please retest on the preview:** password + TOTP login several times, including a deliberate pause before entering the code — previously that raised the odds of the mismatch; it should now succeed every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155vWoCWpjovWX6Csry2iep

---
_Generated by [Claude Code](https://claude.ai/code/session_0155vWoCWpjovWX6Csry2iep)_